### PR TITLE
Adaption for case-sensitive OSes

### DIFF
--- a/fonts/fonts.h
+++ b/fonts/fonts.h
@@ -16,11 +16,11 @@ typedef struct _font_info
 }FONT_INFO; 
 
 
-#include "Fonts/Terminal_8pt.h"
-#include "Fonts/MedProp_11pt.h"
-#include "Fonts/LargeProp_25pt.h"
-#include "Fonts/LCDLarge_24pt.h"
-#include "Fonts/LCDLarge_52pt.h"
+#include "fonts/Terminal_8pt.h"
+#include "fonts/MedProp_11pt.h"
+#include "fonts/LargeProp_25pt.h"
+#include "fonts/LCDLarge_24pt.h"
+#include "fonts/LCDLarge_52pt.h"
 
 
 #endif


### PR DESCRIPTION
None of the code would compile on case-sensitive OSes like Linux because this file used an uppercase F for the fonts directory while all other locations use lowercase